### PR TITLE
removed quotes from url for image

### DIFF
--- a/beach_live/css/style.css
+++ b/beach_live/css/style.css
@@ -26,7 +26,7 @@ html, body{
 	background: yellow;
 	/*background-image: url("../asset/img/csulbTower.jpg");*/
 	/*background-color: #F8CD53;*/
-	background-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.4)), url("https://i.imgur.com/5q1EjuQ.jpg");
+	background-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.4)), url(https://i.imgur.com/5q1EjuQ.jpg);
 	background-repeat: no-repeat;
 	background-size: cover;
 	/*background-attachment:fixed;*/


### PR DESCRIPTION
Having the quotes caused commenting out of css in certain text editors. Removing the quotes in url() is still valid css. Everything works properly.

Source:
https://developer.mozilla.org/en-US/docs/Web/CSS/url